### PR TITLE
Fix imports and add helper methods

### DIFF
--- a/app/src/main/java/icu/nullptr/hidemyapplist/service/ConfigManager.kt
+++ b/app/src/main/java/icu/nullptr/hidemyapplist/service/ConfigManager.kt
@@ -3,8 +3,8 @@ package icu.nullptr.hidemyapplist.service
 import com.tsng.hidemyapplist.R
 import icu.nullptr.hidemyapplist.common.BuildConfig
 import icu.nullptr.hidemyapplist.common.JsonConfig
-import icu.nullptr.hidemyapplist.common.JsonConfig.AndroidProfile
-import icu.nullptr.hidemyapplist.common.JsonConfig.AppFakerConfig
+import icu.nullptr.hidemyapplist.common.AndroidProfile
+import icu.nullptr.hidemyapplist.common.AppFakerConfig
 import icu.nullptr.hidemyapplist.hmaApp
 import icu.nullptr.hidemyapplist.ui.util.makeToast
 
@@ -209,4 +209,9 @@ object ConfigManager {
     fun isFakerEnabled(packageName: String): Boolean {
         return config.appConfigs[packageName]?.isEnabled ?: false
     }
+
+    /**
+     * Legacy API compatible with old naming. Delegates to [isFakerEnabled].
+     */
+    fun isHideEnabled(packageName: String): Boolean = isFakerEnabled(packageName)
 }

--- a/app/src/main/java/icu/nullptr/hidemyapplist/ui/adapter/ProfileAdapter.kt
+++ b/app/src/main/java/icu/nullptr/hidemyapplist/ui/adapter/ProfileAdapter.kt
@@ -5,7 +5,7 @@ package icu.nullptr.hidemyapplist.ui.adapter
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.tsng.hidemyapplist.R
-import icu.nullptr.hidemyapplist.common.JsonConfig
+import icu.nullptr.hidemyapplist.common.AndroidProfile
 import icu.nullptr.hidemyapplist.ui.view.ListItemView
 
 // Adapter để hiển thị danh sách các AndroidProfile
@@ -15,7 +15,7 @@ class ProfileAdapter(
 
     private var profileNames: List<String> = emptyList()
 
-    fun submitList(profiles: Map<String, JsonConfig.AndroidProfile>) {
+    fun submitList(profiles: Map<String, AndroidProfile>) {
         profileNames = profiles.keys.sorted() // Sắp xếp theo tên cho dễ nhìn
         notifyDataSetChanged()
     }

--- a/app/src/main/java/icu/nullptr/hidemyapplist/ui/fragment/AppSettingsFragment.kt
+++ b/app/src/main/java/icu/nullptr/hidemyapplist/ui/fragment/AppSettingsFragment.kt
@@ -16,7 +16,8 @@ import by.kirich1409.viewbindingdelegate.viewBinding
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.tsng.hidemyapplist.R
 import com.tsng.hidemyapplist.databinding.FragmentSettingsBinding // Layout này vẫn dùng chung
-import icu.nullptr.hidemyapplist.common.JsonConfig
+import android.widget.Toast
+import icu.nullptr.hidemyapplist.common.AppFakerConfig
 import icu.nullptr.hidemyapplist.service.ConfigManager
 import icu.nullptr.hidemyapplist.ui.util.setupToolbar
 import icu.nullptr.hidemyapplist.util.PackageHelper
@@ -57,7 +58,7 @@ class AppSettingsFragment : Fragment(R.layout.fragment_settings) {
     class AppPreferenceFragment : PreferenceFragmentCompat() {
 
         private lateinit var packageName: String
-        private lateinit var appFakerConfig: JsonConfig.AppFakerConfig
+        private lateinit var appFakerConfig: AppFakerConfig
 
         private lateinit var enableFakerSwitch: SwitchPreference
         private lateinit var chooseProfilePref: Preference

--- a/app/src/main/java/icu/nullptr/hidemyapplist/ui/fragment/ProfileEditorFragment.kt
+++ b/app/src/main/java/icu/nullptr/hidemyapplist/ui/fragment/ProfileEditorFragment.kt
@@ -14,7 +14,7 @@ import by.kirich1409.viewbindingdelegate.viewBinding
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.tsng.hidemyapplist.R
 import com.tsng.hidemyapplist.databinding.FragmentProfileEditorBinding
-import icu.nullptr.hidemyapplist.common.JsonConfig
+import icu.nullptr.hidemyapplist.common.AndroidProfile
 import icu.nullptr.hidemyapplist.service.ConfigManager
 import icu.nullptr.hidemyapplist.ui.util.setupToolbar
 import java.util.*
@@ -25,7 +25,7 @@ class ProfileEditorFragment : Fragment(R.layout.fragment_profile_editor) {
     private val binding by viewBinding<FragmentProfileEditorBinding>()
     private val args: ProfileEditorFragmentArgs by navArgs()
 
-    private var currentProfile: JsonConfig.AndroidProfile? = null
+    private var currentProfile: AndroidProfile? = null
     private var originalProfileName: String? = null
     private var isCreatingNew: Boolean = true
 
@@ -79,7 +79,7 @@ class ProfileEditorFragment : Fragment(R.layout.fragment_profile_editor) {
 
     private fun loadProfileData() {
         if (isCreatingNew) {
-            currentProfile = JsonConfig.AndroidProfile()
+            currentProfile = AndroidProfile()
             binding.editProfileName.requestFocus()
         } else {
             currentProfile = ConfigManager.getProfile(originalProfileName!!)
@@ -105,8 +105,8 @@ class ProfileEditorFragment : Fragment(R.layout.fragment_profile_editor) {
         }
     }
 
-    private fun collectDataFromViews(): JsonConfig.AndroidProfile {
-        return JsonConfig.AndroidProfile(
+    private fun collectDataFromViews(): AndroidProfile {
+        return AndroidProfile(
             imei1 = binding.editImei1.text.toString().ifEmpty { null },
             imei2 = binding.editImei2.text.toString().ifEmpty { null },
             androidId = binding.editAndroidId.text.toString().ifEmpty { null },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,6 +110,7 @@
     <string name="logs_clear">Xóa Nhật ký</string>
     <string name="logs_empty">Không có nhật ký để lưu</string>
     <string name="logs_saved">Nhật ký đã được lưu</string>
+    <string name="do_not_dual">Vui lòng cài đặt ứng dụng chỉ một lần, không nhân bản.</string>
 
     <!-- Cài đặt (SettingsFragment) -->
     <string name="settings_module">Module</string>

--- a/xposed/build.gradle.kts
+++ b/xposed/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
     implementation(libs.com.android.tools.build.apksig)
     implementation(libs.com.github.kyuubiran.ezxhelper)
     implementation(libs.dev.rikka.hidden.compat)
+    implementation(kotlin("reflect"))
     compileOnly(libs.de.robv.android.xposed.api)
     compileOnly(libs.dev.rikka.hidden.stub)
 }

--- a/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/CentralService.kt
+++ b/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/CentralService.kt
@@ -9,6 +9,7 @@ import icu.nullptr.hidemyapplist.common.Constants
 import icu.nullptr.hidemyapplist.common.IAPFService
 import icu.nullptr.hidemyapplist.common.JsonConfig
 import java.io.File
+import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.*
 import kotlin.reflect.full.memberProperties
@@ -140,7 +141,9 @@ class CentralService(val pms: IPackageManager) : IAPFService.Stub() {
             val profile = config.profiles[appConfig.appliedProfileName] ?: return null
             
             return try {
-                profile::class.memberProperties.find { it.name == key }?.get(profile)
+                val prop = profile::class.memberProperties
+                    .find { it.name == key } as? kotlin.reflect.KProperty1<AndroidProfile, *>
+                prop?.get(profile)
             } catch (e: Throwable) {
                 logE(TAG, "Reflection failed for key: $key", e)
                 null

--- a/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/hook/impl/AndroidIdHook.kt
+++ b/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/hook/impl/AndroidIdHook.kt
@@ -4,6 +4,9 @@ package icu.nullptr.hidemyapplist.xposed.hook.impl
 
 import android.provider.Settings
 import com.github.kyuubiran.ezxhelper.utils.*
+import icu.nullptr.hidemyapplist.xposed.logD
+import icu.nullptr.hidemyapplist.xposed.logE
+import icu.nullptr.hidemyapplist.xposed.logI
 import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.callbacks.XC_LoadPackage
 import icu.nullptr.hidemyapplist.xposed.CentralService

--- a/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/hook/impl/BuildHook.kt
+++ b/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/hook/impl/BuildHook.kt
@@ -3,8 +3,8 @@
 package icu.nullptr.hidemyapplist.xposed.hook.impl
 
 import android.os.Build
-import com.github.kyuubiran.ezxhelper.utils.logD
-import com.github.kyuubiran.ezxhelper.utils.logE
+import icu.nullptr.hidemyapplist.xposed.logD
+import icu.nullptr.hidemyapplist.xposed.logE
 import de.robv.android.xposed.XposedHelpers
 import de.robv.android.xposed.callbacks.XC_LoadPackage
 import icu.nullptr.hidemyapplist.xposed.CentralService

--- a/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/hook/impl/SystemPropertiesHook.kt
+++ b/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/hook/impl/SystemPropertiesHook.kt
@@ -3,6 +3,9 @@
 package icu.nullptr.hidemyapplist.xposed.hook.impl
 
 import com.github.kyuubiran.ezxhelper.utils.*
+import icu.nullptr.hidemyapplist.xposed.logD
+import icu.nullptr.hidemyapplist.xposed.logE
+import icu.nullptr.hidemyapplist.xposed.logI
 import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.callbacks.XC_LoadPackage
 import icu.nullptr.hidemyapplist.xposed.CentralService


### PR DESCRIPTION
## Summary
- add legacy isHideEnabled method to ConfigManager
- import Toast in AppSettingsFragment
- define missing `do_not_dual` string
- fix log function imports in Xposed hooks
- handle reflection generics in CentralService

## Testing
- `sh gradlew :app:assembleDebug` *(fails: Compilation errors)*

------
https://chatgpt.com/codex/tasks/task_b_6864f49a243c832293412d7cee7db873